### PR TITLE
Update helm to 2.5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Mario Siegenthaler <mario.siegenthaler@linkyard.ch>
 
 RUN apk add --update --no-cache ca-certificates git
 
-ENV VERSION v2.5.0
+ENV VERSION v2.5.1
 ENV FILENAME helm-${VERSION}-linux-amd64.tar.gz
 
 WORKDIR /


### PR DESCRIPTION
* 2.5.1 is a bugfix release as per https://github.com/kubernetes/helm/releases/tag/v2.5.1
* This change is verified by running `docker build .`