### PR TITLE
Reduce the image size from 44MB to 29MB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,10 @@ ENV FILENAME helm-${VERSION}-linux-amd64.tar.gz
 
 WORKDIR /
 
-ADD http://storage.googleapis.com/kubernetes-helm/${FILENAME} /tmp
-
-RUN tar -zxvf /tmp/${FILENAME} -C /tmp \
+RUN apk add --update -t deps curl tar gzip \
+  && curl -L http://storage.googleapis.com/kubernetes-helm/${FILENAME} | tar zxv -C /tmp \
   && mv /tmp/linux-amd64/helm /bin/helm \
+  && apk del --purge deps curl tar gzip \
   && rm -rf /tmp
 
 ENTRYPOINT ["/bin/helm"]


### PR DESCRIPTION
By removing the layer containing a temporary tgz archive of helm which isn't necessary for the purpose of this image - running helm

Before the improvement:

![image](https://user-images.githubusercontent.com/22009/28699214-4570679e-7383-11e7-82f6-444f01c2e40d.png)

And after that:

![image](https://user-images.githubusercontent.com/22009/28699234-60fd0bde-7383-11e7-8b94-fc09c1d97a24.png)

This change is verified by running `docker build .` and then running `docker run mumoshu/helm:smaller version -c`
