### PR TITLE
Update to Helm 2.12.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ LABEL maintainer="Mario Siegenthaler <mario.siegenthaler@linkyard.ch>"
 
 RUN apk add --update --no-cache ca-certificates git
 
-ENV VERSION=v2.11.0
+ENV VERSION=v2.12.2
 ENV FILENAME=helm-${VERSION}-linux-amd64.tar.gz
-ENV SHA256SUM=02a4751586d6a80f6848b58e7f6bd6c973ffffadc52b4c06652db7def02773a1
+ENV SHA256SUM=edad6d5e594408b996b8d758a04948f89dab15fa6c6ea6daee3709f8c099df6d
 
 WORKDIR /
 


### PR DESCRIPTION
A security hole was found in older Helm versions.  While this is
not exploitable in servers, it is helpful to be consistent with clients,
and clients must be upgraded.

(I don't know what the canonical way of obtaining the sha256sum of the
upstream Helm tarball is. It is worth double-checking that my computation
is correct; that is, that I ran sha256 against the true release tarball.)