### PR TITLE
updating to 2.15.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM alpine:3.9 as build
+FROM alpine:3.10 as build
 LABEL maintainer="Mario Siegenthaler <mario.siegenthaler@linkyard.ch>"
 
 RUN apk add --update --no-cache ca-certificates git
 
-ENV VERSION=v2.14.1
+ENV VERSION=v2.15.2
 ENV FILENAME=helm-${VERSION}-linux-amd64.tar.gz
-ENV SHA256SUM=804f745e6884435ef1343f4de8940f9db64f935cd9a55ad3d9153d064b7f5896
+ENV SHA256SUM=a9d2db920bd4b3d824729bbe1ff3fa57ad27760487581af6e5d3156d1b3c2511
 
 WORKDIR /
 


### PR DESCRIPTION
Bumped version of build container, helm version and matching SHA